### PR TITLE
[WKAPP] Redesign Sessions tab with grouped workouts and loading fix

### DIFF
--- a/WorkoutApp/WorkoutApp/Flows/Main/Home/HomeView.swift
+++ b/WorkoutApp/WorkoutApp/Flows/Main/Home/HomeView.swift
@@ -14,113 +14,152 @@ struct Home {
     struct ContentView: View {
 
         var viewModel: ViewModel
-        
+
         var body: some View {
-            if viewModel.workouts.isEmpty {
-                Text("You don't have any workouts tracked. Open the watch application and get started!")
-                    .multilineTextAlignment(.center)
-                    .font(.heading1)
-                    .foregroundStyle(Color.onBackground)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.background)
-                    .refreshable {
-                        await viewModel.refreshWorkouts()
-                    }
-                    .overlay {
-                        loadingView
-                    }
-            } else {
-                ScrollView {
-                    LazyVStack(alignment:.leading, spacing: 10) {
-                        
-                        Text("Workout sessions")
-                            .foregroundStyle(Color.onBackground)
-                            .font(.heading1)
-                            .padding(.bottom, 10)
-                        ForEach(viewModel.workouts) { workout in
-                            Button {
-                                viewModel.handleWorkoutTapped(for: workout)
-                            } label: {
-                                WorkoutCardView(workout: workout)
-                            }
-                            .buttonStyle(.plain)
+            ScrollView {
+                if viewModel.workouts.isEmpty && !viewModel.isLoading {
+                    EmptyStateView()
+                } else if !viewModel.workouts.isEmpty {
+                    LazyVStack(alignment: .leading, spacing: 16) {
+                        ForEach(viewModel.groupedWorkouts) { group in
+                            WorkoutSectionView(
+                                group: group,
+                                onSessionTapped: { session in
+                                    viewModel.handleWorkoutTapped(for: session)
+                                }
+                            )
                         }
                     }
                     .padding()
                 }
-                .frame(maxHeight: .infinity, alignment: .top)
-                .background(Color.background)
-                .refreshable {
-                    await viewModel.refreshWorkouts()
-                }
-                .overlay {
-                    loadingView
+            }
+            .navigationTitle("Sessions")
+            .navigationSubtitle(sessionCountSubtitle)
+            .frame(maxHeight: .infinity, alignment: .top)
+            .background(Color.background)
+            .refreshable {
+                await viewModel.refreshWorkouts()
+            }
+            .overlay {
+                if viewModel.isLoading {
+                    LoadingOverlayView()
                 }
             }
         }
-        
-        @ViewBuilder
-        private var loadingView: some View {
-            if viewModel.isLoading {
-                ZStack {
-                    Color.background
-                    ActivityIndicator(color: .red, scale: 2)
-                }
-                .ignoresSafeArea()
+
+        private var sessionCountSubtitle: String {
+            let count = viewModel.workouts.count
+            return "\(count) session\(count == 1 ? "" : "s")"
+        }
+    }
+}
+
+// MARK: - Loading Overlay View
+private struct LoadingOverlayView: View {
+    var body: some View {
+        ZStack {
+            Color.background.opacity(0.8)
+            ProgressView()
+                .scaleEffect(1.2)
+        }
+    }
+}
+
+// MARK: - Workout Section View
+private struct WorkoutSectionView: View {
+    let group: WorkoutSessionGroup
+    let onSessionTapped: (WorkoutSession) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            SectionHeaderView(title: group.title)
+
+            ForEach(group.sessions) { session in
+                SessionCardButton(
+                    session: session,
+                    onTap: { onSessionTapped(session) }
+                )
             }
         }
     }
 }
 
-//#if DEBUG
-//struct Home_Preview: PreviewProvider {
-//    
-//    struct HomeNoWorkoutsTestView: View {
-//        
-//        @StateObject private var viewModel: Home.ViewModel = .init(
-//            workoutRepository: MockedWorkoutSessionEmptyRepository(),
-//            healthKitManager: HealthKitManager()
-//        )
-//        
-//        init() {
-//            viewModel.workouts = []
-//        }
-//        
-//        var body: some View {
-//            Home.ContentView(viewModel: viewModel)
-//        }
-//    }
-//    
-//    struct HomeTestView: View {
-//        
-//        @StateObject private var viewModel: Home.ViewModel
-//        
-//        init() {
-//            self._viewModel = .init(wrappedValue: .init(
-//                workoutRepository: MockedWorkoutSessionRepository(),
-//                healthKitManager: HealthKitManager()))
-//            viewModel.workouts = WorkoutSession.mockedSet
-//        }
-//        
-//        var body: some View {
-//            Home.ContentView(viewModel: viewModel)
-//                .onAppear {
-//                    viewModel.workouts = WorkoutSession.mockedSet
-//                }
-//        }
-//    }
-//    
-//    static var previews: some View {
-//        ForEach(previewDevices) { device in
-//            HomeTestView()
-//                .preview(device)
-//                
-//        }
-//        
-//        ForEach(previewDevices) { device in
-//            HomeNoWorkoutsTestView()
-//                .preview(device)
-//        }
-//    }
-//}
-//#endif
+// MARK: - Section Header View
+private struct SectionHeaderView: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.heading3)
+            .foregroundStyle(Color.onBackground)
+    }
+}
+
+// MARK: - Session Card Button
+private struct SessionCardButton: View {
+    let session: WorkoutSession
+    let onTap: () -> Void
+    @State private var tapCount = 0
+
+    var body: some View {
+        Button(action: {
+            tapCount += 1
+            onTap()
+        }) {
+            WorkoutCardView(workout: session)
+        }
+        .buttonStyle(.plain)
+        .sensoryFeedback(.impact(weight: .light), trigger: tapCount)
+    }
+}
+
+// MARK: - Empty State View
+private struct EmptyStateView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "figure.strengthtraining.traditional")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary.opacity(0.6))
+
+            VStack(spacing: 4) {
+                Text("No Workout Sessions")
+                    .font(.title2)
+                    .bold()
+                    .foregroundStyle(Color.onBackground)
+
+                Text("Complete a workout on your Apple Watch to see it here")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical)
+    }
+}
+
+//MARK: - Previews
+#Preview("With sessions") {
+    NavigationStack {
+        Home.ContentView(
+            viewModel: .init(
+                workoutRepository: MockedWorkoutSessionRepository(),
+                healthKitManager: MockedHealthKitManager(),
+                navigationManager: WorkoutSessionsNavigationManager()
+            )
+        )
+    }
+}
+
+#Preview("Empty") {
+    NavigationStack {
+        Home.ContentView(
+            viewModel: .init(
+                workoutRepository: MockedWorkoutSessionEmptyRepository(),
+                healthKitManager: MockedHealthKitManager(),
+                navigationManager: WorkoutSessionsNavigationManager()
+            )
+        )
+    }
+}

--- a/WorkoutApp/WorkoutApp/Flows/Main/Home/HomeViewModel.swift
+++ b/WorkoutApp/WorkoutApp/Flows/Main/Home/HomeViewModel.swift
@@ -9,10 +9,18 @@ import Combine
 import Foundation
 import SwiftUI
 
+// MARK: - Workout Session Group
+struct WorkoutSessionGroup: Identifiable {
+    let id: String
+    let title: String
+    let sessions: [WorkoutSession]
+}
+
 extension Home {
 
     @Observable class ViewModel {
 
+        // MARK: - Properties
         var workouts: [WorkoutSession] = []
         var isLoading = false
 
@@ -22,6 +30,43 @@ extension Home {
         @ObservationIgnored private var cancellables = Set<AnyCancellable>()
         @ObservationIgnored private var loadTask: Task<Void, Never>?
 
+        var groupedWorkouts: [WorkoutSessionGroup] {
+            let calendar = Calendar.current
+            let now = Date.now
+
+            var today: [WorkoutSession] = []
+            var yesterday: [WorkoutSession] = []
+            var thisWeek: [WorkoutSession] = []
+            var thisMonth: [WorkoutSession] = []
+            var earlier: [WorkoutSession] = []
+
+            let sorted = workouts.sorted { ($0.endDate ?? .distantPast) > ($1.endDate ?? .distantPast) }
+
+            for session in sorted {
+                let date = session.endDate ?? .distantPast
+                if calendar.isDateInToday(date) {
+                    today.append(session)
+                } else if calendar.isDateInYesterday(date) {
+                    yesterday.append(session)
+                } else if calendar.isDate(date, equalTo: now, toGranularity: .weekOfYear) {
+                    thisWeek.append(session)
+                } else if calendar.isDate(date, equalTo: now, toGranularity: .month) {
+                    thisMonth.append(session)
+                } else {
+                    earlier.append(session)
+                }
+            }
+
+            return [
+                WorkoutSessionGroup(id: "today", title: "Today", sessions: today),
+                WorkoutSessionGroup(id: "yesterday", title: "Yesterday", sessions: yesterday),
+                WorkoutSessionGroup(id: "thisWeek", title: "This Week", sessions: thisWeek),
+                WorkoutSessionGroup(id: "thisMonth", title: "This Month", sessions: thisMonth),
+                WorkoutSessionGroup(id: "earlier", title: "Earlier", sessions: earlier),
+            ].filter { !$0.sessions.isEmpty }
+        }
+
+        // MARK: - Initializer
         init(workoutRepository: any WorkoutSessionRepository,
              healthKitManager: any HealthKitManagerProtocol,
              navigationManager: WorkoutSessionsNavigationManager) {
@@ -32,9 +77,8 @@ extension Home {
             loadWorkouts()
         }
 
+        // MARK: - Public Methods
         func refreshWorkouts() async {
-            isLoading = true
-            defer { isLoading = false }
             do {
                 try await workoutRepository.loadData()
             } catch {
@@ -42,6 +86,11 @@ extension Home {
             }
         }
 
+        func handleWorkoutTapped(for session: WorkoutSession) {
+            navigationManager?.push(WorkoutRoute(workout: session))
+        }
+
+        // MARK: - Private Methods
         private func subscribeToWorkoutSessions() {
             workoutRepository
                 .entitiesPublisher
@@ -62,10 +111,6 @@ extension Home {
                     print("Error while loading workouts: \(error.localizedDescription)")
                 }
             }
-        }
-
-        func handleWorkoutTapped(for session: WorkoutSession) {
-            navigationManager?.push(WorkoutRoute(workout: session))
         }
     }
 }

--- a/WorkoutApp/WorkoutApp/Reusables/WorkoutCards/WorkoutCardView.swift
+++ b/WorkoutApp/WorkoutApp/Reusables/WorkoutCards/WorkoutCardView.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
+// MARK: - TimeInterval Formatting
 extension TimeInterval {
-    
+
     func formatted() -> String {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
@@ -17,35 +18,123 @@ extension TimeInterval {
     }
 }
 
+// MARK: - WorkoutCardView
 struct WorkoutCardView: View {
-    
+
     let workout: WorkoutSession
-    
+
+    private let cardCornerRadius: CGFloat = 14
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
-                Text(workout.title ?? " No title")
-                    .foregroundStyle(Color.onSurface)
-                    .font(.heading3)
-                Text(workout.duration?.formatted() ?? "0:00:00")
-                    .foregroundStyle(Color.onSurface)
-                    .bold()
-                Text("\(workout.activeCalories ?? 0) KCAL")
-                    .foregroundStyle(Color.onSurface)
-                
+        HStack(spacing: 0) {
+            AccentBar()
+
+            VStack(alignment: .leading, spacing: 8) {
+                CardHeader(
+                    title: workout.title ?? "No Title",
+                    templateName: workout.workoutTemplate.name,
+                    date: workout.endDate ?? .now
+                )
+
+                MetricsRow(
+                    duration: workout.duration,
+                    calories: workout.activeCalories,
+                    heartRate: workout.averageHeartRate
+                )
             }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .overlay(dateView, alignment: .bottomTrailing)
-        .padding()
+            .padding(.vertical, 14)
+            .padding(.horizontal, 14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
         .background(Color.surface)
-        .cornerRadius(15)
+        .clipShape(.rect(cornerRadius: cardCornerRadius))
     }
 }
 
-private extension WorkoutCardView {
-    
-    var dateView: some View {
-        Text(workout.endDate ?? .now, style: .date)
-            .foregroundStyle(Color.onSurface)
+// MARK: - Accent Bar
+private struct AccentBar: View {
+    var body: some View {
+        Color.primaryColor
+            .frame(width: 4)
+    }
+}
+
+// MARK: - Card Header
+private struct CardHeader: View {
+    let title: String
+    let templateName: String
+    let date: Date
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(Color.onSurface)
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text(date, format: .dateTime.month(.abbreviated).day())
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(templateName)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+}
+
+// MARK: - Metrics Row
+private struct MetricsRow: View {
+    let duration: TimeInterval?
+    let calories: Int?
+    let heartRate: Int?
+
+    var body: some View {
+        HStack(spacing: 16) {
+            MetricItem(
+                icon: "clock.fill",
+                value: duration?.formatted() ?? "0m 0s",
+                color: .green
+            )
+
+            MetricItem(
+                icon: "flame.fill",
+                value: "\(calories ?? 0) kcal",
+                color: .primaryColor
+            )
+
+            if let heartRate {
+                MetricItem(
+                    icon: "heart.fill",
+                    value: "\(heartRate) bpm",
+                    color: .red
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Metric Item
+private struct MetricItem: View {
+    let icon: String
+    let value: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.caption2)
+                .foregroundStyle(color)
+
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(Color.onSurface)
+        }
     }
 }
 
@@ -54,7 +143,13 @@ struct WorkoutCardView_Previews: PreviewProvider {
     static var previews: some View {
         ZStack {
             Color.background
-            WorkoutCardView(workout: .mocked1)
+                .ignoresSafeArea()
+
+            VStack(spacing: 12) {
+                WorkoutCardView(workout: .mocked1)
+                WorkoutCardView(workout: .mocked2)
+            }
+            .padding()
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Grouped sessions by date** — sections for Today, Yesterday, This Week, This Month, and Earlier with headers
- **Redesigned WorkoutCardView** — accent bar, card header with template name + date, metrics row (duration, calories, heart rate)
- **Fixed pull-to-refresh spinner** — separated initial load (`isLoading`) from refresh so `.refreshable` uses its native indicator instead of flashing a full-screen opaque overlay
- **Replaced loading overlay** — semi-transparent `LoadingOverlayView` with native `ProgressView` instead of opaque `ActivityIndicator`
- **Updated previews** — replaced commented-out `PreviewProvider` with `#Preview` macros using mocked dependencies

## Test plan
- [ ] Pull-to-refresh shows only the native SwiftUI spinner, no full-screen overlay
- [ ] Initial load still shows the semi-transparent loading overlay
- [ ] Sessions are grouped correctly by date sections
- [ ] Workout cards display title, template name, date, duration, calories, and heart rate
- [ ] Empty state displays correctly when no sessions exist
- [ ] Xcode previews render for both "With sessions" and "Empty" variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)