### PR TITLE
[WKAPP] Add exercise definitions model, API layer, and browse UI (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,4 +90,5 @@ fastlane/test_output
 iOSInjectionProject/
 .DS_Store
 .cursor
-.claude/settings.local.json
+.claude/
+scratch/

--- a/WorkoutApp/WorkoutApp.xcodeproj/project.pbxproj
+++ b/WorkoutApp/WorkoutApp.xcodeproj/project.pbxproj
@@ -7,9 +7,28 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1421F40CEFEF4CEC9960C718 /* PaginatedResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496FF9E61FA04F3D84FA2EE4 /* PaginatedResponse.swift */; };
+		147CFE6D28534CF5AFB38970 /* ExerciseForce.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3C2F7E665B48539B14929A /* ExerciseForce.swift */; };
+		277B3614B7CC4848B1F86532 /* ExerciseDefinitionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A70369596A341398F99629A /* ExerciseDefinitionRepository.swift */; };
+		299DF74DE6CD41EA89466C26 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA310079173461AA2EE3EDE /* APIClient.swift */; };
+		2D21FFB1F5184D1E9CB843A3 /* Equipment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A7574F575A4D6DB00D7C2C /* Equipment.swift */; };
 		411D590E752C4069824AE3E4 /* WorkoutsFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411D590E752C4069824AE3E3 /* WorkoutsFlowCoordinator.swift */; };
-		7E8E940844B64EEC963A6E56 /* WatchNavigationRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7D4726D412847A6AAF6DFF1 /* WatchNavigationRoutes.swift */; };
 		46B24FAF1E594D6A9B70FDD5 /* WatchWorkoutsNavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481245F321F04917B25DBA02 /* WatchWorkoutsNavigationManager.swift */; };
+		4A7A0CE9E32F4B3BADE8B1E2 /* ExerciseDefinitionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F39C58C85634BAE83B66B49 /* ExerciseDefinitionDetailView.swift */; };
+		4BABEACC69B447A08CA81F27 /* MuscleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5123870C064A52971EAB82 /* MuscleGroup.swift */; };
+		4E3CB142D4B14C51AEAB284A /* ExerciseDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B2B886029C4C6AAB52D4B7 /* ExerciseDefinition.swift */; };
+		5868170268BF42338B076B4D /* ExerciseMechanic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB6FC6FFE7D40D08E8F29F9 /* ExerciseMechanic.swift */; };
+		5CDD48E5DDF24AE5B639DD7A /* ExerciseCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F68B46918774C4A87193839 /* ExerciseCategory.swift */; };
+		79118A677BBC48769758007F /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5535D80206894F51B783A99A /* NetworkError.swift */; };
+		7E8E940844B64EEC963A6E56 /* WatchNavigationRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7D4726D412847A6AAF6DFF1 /* WatchNavigationRoutes.swift */; };
+		AD2F01D969F24879B721708C /* ExerciseDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B2B886029C4C6AAB52D4B7 /* ExerciseDefinition.swift */; };
+		BB505ADDA3FF498A8E9D6223 /* Equipment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A7574F575A4D6DB00D7C2C /* Equipment.swift */; };
+		BEEFCFFB1F8B41A09640B66B /* MuscleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5123870C064A52971EAB82 /* MuscleGroup.swift */; };
+		C3F2A70F91DF497385402FD9 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943B909EC6814CBC9C7DF2BE /* Endpoint.swift */; };
+		D3266F3A00B24EA3A0939313 /* ExerciseLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD30AF7A3C3472E81DE4CEA /* ExerciseLevel.swift */; };
+		D788CADED88E486B9222A152 /* ExerciseCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F68B46918774C4A87193839 /* ExerciseCategory.swift */; };
+		D8E92802F35F4D18BEFAEED6 /* ExerciseLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD30AF7A3C3472E81DE4CEA /* ExerciseLevel.swift */; };
+		DCF3B98AD0404924AB46D6E0 /* ExerciseMechanic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AB6FC6FFE7D40D08E8F29F9 /* ExerciseMechanic.swift */; };
 		DE012DDE2A01446F0071601B /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE012DDB2A01446F0071601B /* HomeView.swift */; };
 		DE012DDF2A01446F0071601B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE012DDC2A01446F0071601B /* HomeViewModel.swift */; };
 		DE012DE32A0146CC0071601B /* Color + Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE012DE22A0146CC0071601B /* Color + Extensions.swift */; };
@@ -79,7 +98,6 @@
 		DEDFC2F62A0B827800E736E0 /* HealthKitAuthorizationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDFC2F52A0B827800E736E0 /* HealthKitAuthorizationView.swift */; };
 		DEDFC2F82A0B834700E736E0 /* HealthKitAuthorizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDFC2F72A0B834700E736E0 /* HealthKitAuthorizationViewModel.swift */; };
 		DEDFC2FA2A0B83F300E736E0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDFC2F92A0B83F300E736E0 /* Constants.swift */; };
-
 		DEE2FBEC2A1A2B850062437A /* ExerciseSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2FBEB2A1A2B850062437A /* ExerciseSet.swift */; };
 		DEE2FBEE2A1A2BA60062437A /* Workout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2FBED2A1A2BA60062437A /* Workout.swift */; };
 		DEE2FBF02A1A2BB50062437A /* PerformedExercise.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE2FBEF2A1A2BB50062437A /* PerformedExercise.swift */; };
@@ -101,6 +119,7 @@
 		DEF951A92A27887800D80381 /* WorkoutTemplateBuilderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF951A82A27887800D80381 /* WorkoutTemplateBuilderViewModel.swift */; };
 		DEF951AB2A27E0C800D80381 /* ExerciseCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF951AA2A27E0C800D80381 /* ExerciseCardView.swift */; };
 		DEF951AD2A27E12300D80381 /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF951AC2A27E12300D80381 /* EditView.swift */; };
+		F032F7635E3744C0A7321770 /* ExerciseForce.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3C2F7E665B48539B14929A /* ExerciseForce.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -128,9 +147,20 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1FA310079173461AA2EE3EDE /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		2A70369596A341398F99629A /* ExerciseDefinitionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDefinitionRepository.swift; sourceTree = "<group>"; };
+		2AB6FC6FFE7D40D08E8F29F9 /* ExerciseMechanic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseMechanic.swift; sourceTree = "<group>"; };
+		3D5123870C064A52971EAB82 /* MuscleGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuscleGroup.swift; sourceTree = "<group>"; };
 		411D590E752C4069824AE3E3 /* WorkoutsFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutsFlowCoordinator.swift; sourceTree = "<group>"; };
-		F7D4726D412847A6AAF6DFF1 /* WatchNavigationRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNavigationRoutes.swift; sourceTree = "<group>"; };
 		481245F321F04917B25DBA02 /* WatchWorkoutsNavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWorkoutsNavigationManager.swift; sourceTree = "<group>"; };
+		496FF9E61FA04F3D84FA2EE4 /* PaginatedResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedResponse.swift; sourceTree = "<group>"; };
+		5535D80206894F51B783A99A /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		59A7574F575A4D6DB00D7C2C /* Equipment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Equipment.swift; sourceTree = "<group>"; };
+		7F39C58C85634BAE83B66B49 /* ExerciseDefinitionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDefinitionDetailView.swift; sourceTree = "<group>"; };
+		943B909EC6814CBC9C7DF2BE /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		9F68B46918774C4A87193839 /* ExerciseCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseCategory.swift; sourceTree = "<group>"; };
+		CF3C2F7E665B48539B14929A /* ExerciseForce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseForce.swift; sourceTree = "<group>"; };
+		CFD30AF7A3C3472E81DE4CEA /* ExerciseLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseLevel.swift; sourceTree = "<group>"; };
 		DE012DDB2A01446F0071601B /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		DE012DDC2A01446F0071601B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		DE012DE22A0146CC0071601B /* Color + Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color + Extensions.swift"; sourceTree = "<group>"; };
@@ -194,7 +224,6 @@
 		DEDFC2F52A0B827800E736E0 /* HealthKitAuthorizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitAuthorizationView.swift; sourceTree = "<group>"; };
 		DEDFC2F72A0B834700E736E0 /* HealthKitAuthorizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitAuthorizationViewModel.swift; sourceTree = "<group>"; };
 		DEDFC2F92A0B83F300E736E0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-
 		DEE2FBEB2A1A2B850062437A /* ExerciseSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseSet.swift; sourceTree = "<group>"; };
 		DEE2FBED2A1A2BA60062437A /* Workout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workout.swift; sourceTree = "<group>"; };
 		DEE2FBEF2A1A2BB50062437A /* PerformedExercise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformedExercise.swift; sourceTree = "<group>"; };
@@ -210,6 +239,8 @@
 		DEF951A82A27887800D80381 /* WorkoutTemplateBuilderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutTemplateBuilderViewModel.swift; sourceTree = "<group>"; };
 		DEF951AA2A27E0C800D80381 /* ExerciseCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseCardView.swift; sourceTree = "<group>"; };
 		DEF951AC2A27E12300D80381 /* EditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
+		F4B2B886029C4C6AAB52D4B7 /* ExerciseDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseDefinition.swift; sourceTree = "<group>"; };
+		F7D4726D412847A6AAF6DFF1 /* WatchNavigationRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNavigationRoutes.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -234,6 +265,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BA54759ECE684A2CA067B6E0 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				1FA310079173461AA2EE3EDE /* APIClient.swift */,
+				943B909EC6814CBC9C7DF2BE /* Endpoint.swift */,
+				496FF9E61FA04F3D84FA2EE4 /* PaginatedResponse.swift */,
+				5535D80206894F51B783A99A /* NetworkError.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
 		DE012DD92A0144220071601B /* Home */ = {
 			isa = PBXGroup;
 			children = (
@@ -296,13 +338,6 @@
 				DE3252AA2C482D3800B3B6F0 /* CustomLogger.swift */,
 			);
 			path = Logging;
-			sourceTree = "<group>";
-		};
-		DE3353EB29ED8A95002D4891 /* Networking */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Networking;
 			sourceTree = "<group>";
 		};
 		DE3D0A512A0D66ED00EF23CB /* Views */ = {
@@ -428,9 +463,9 @@
 				DE1E5CD52EFB541100EF4D55 /* WorkoutAppApp.swift */,
 				DE10524A2A06B34200399C2B /* WorkoutApp.entitlements */,
 				DE012DED2A02CAFA0071601B /* DataLayer */,
-				DE3353EB29ED8A95002D4891 /* Networking */,
 				DEDA4ABE29CF6110000AFBBF /* Flows */,
 				DEDA4AC229CF613F000AFBBF /* Model */,
+				BA54759ECE684A2CA067B6E0 /* Networking */,
 				DEDA4AC129CF6133000AFBBF /* Services */,
 				DEDA4AC029CF612B000AFBBF /* Utils */,
 				DEDA4ABF29CF611B000AFBBF /* Reusables */,
@@ -493,6 +528,13 @@
 				DE012DE42A014DD90071601B /* WorkoutSession.swift */,
 				DE012DE62A0188DD0071601B /* WorkoutSession + Mocked.swift */,
 				DE3D0A582A0FA32E00EF23CB /* Exercise.swift */,
+				3D5123870C064A52971EAB82 /* MuscleGroup.swift */,
+				59A7574F575A4D6DB00D7C2C /* Equipment.swift */,
+				9F68B46918774C4A87193839 /* ExerciseCategory.swift */,
+				CFD30AF7A3C3472E81DE4CEA /* ExerciseLevel.swift */,
+				CF3C2F7E665B48539B14929A /* ExerciseForce.swift */,
+				2AB6FC6FFE7D40D08E8F29F9 /* ExerciseMechanic.swift */,
+				F4B2B886029C4C6AAB52D4B7 /* ExerciseDefinition.swift */,
 				DEE2FBEB2A1A2B850062437A /* ExerciseSet.swift */,
 				DEE2FBED2A1A2BA60062437A /* Workout.swift */,
 				DEE2FBEF2A1A2BB50062437A /* PerformedExercise.swift */,
@@ -515,7 +557,6 @@
 			isa = PBXGroup;
 			children = (
 				DE1052482A06AF9800399C2B /* HealthKitManager.swift */,
-
 				DEA6064C2A1DF8E50061BF9A /* WatchCommunicator.swift */,
 			);
 			path = Managers;
@@ -528,6 +569,7 @@
 				DE012DF02A02CBD10071601B /* WorkoutSessionRepository.swift */,
 				DEE2FBF42A1A4AF80062437A /* WorkoutRepository.swift */,
 				DEDC056D2A3F69E5007E90B4 /* ExerciseRepository.swift */,
+				2A70369596A341398F99629A /* ExerciseDefinitionRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -559,6 +601,7 @@
 				DEF951AA2A27E0C800D80381 /* ExerciseCardView.swift */,
 				DEF951AC2A27E12300D80381 /* EditView.swift */,
 				DE63022A2A2B32DC00BA5E54 /* AddExerciseView.swift */,
+				7F39C58C85634BAE83B66B49 /* ExerciseDefinitionDetailView.swift */,
 			);
 			path = WorkoutTemplateBuilder;
 			sourceTree = "<group>";
@@ -691,6 +734,13 @@
 				DED4576F2A1E70B900066DAE /* Message.swift in Sources */,
 				DE3D0A552A0D797900EF23CB /* ActivityRingsView.swift in Sources */,
 				DE5041FE2A21054200B7D498 /* Exercise.swift in Sources */,
+				BEEFCFFB1F8B41A09640B66B /* MuscleGroup.swift in Sources */,
+				BB505ADDA3FF498A8E9D6223 /* Equipment.swift in Sources */,
+				5CDD48E5DDF24AE5B639DD7A /* ExerciseCategory.swift in Sources */,
+				D8E92802F35F4D18BEFAEED6 /* ExerciseLevel.swift in Sources */,
+				147CFE6D28534CF5AFB38970 /* ExerciseForce.swift in Sources */,
+				DCF3B98AD0404924AB46D6E0 /* ExerciseMechanic.swift in Sources */,
+				AD2F01D969F24879B721708C /* ExerciseDefinition.swift in Sources */,
 				DE3D0A502A0D66CF00EF23CB /* MetricsView.swift in Sources */,
 				DEAF7F4D2A0D3BF000682ACD /* SessionPagingView.swift in Sources */,
 				DEF951942A24B09400D80381 /* Font + Extension.swift in Sources */,
@@ -743,6 +793,19 @@
 				DEDC056E2A3F69E5007E90B4 /* ExerciseRepository.swift in Sources */,
 				DE012DEC2A01944A0071601B /* Font + Extension.swift in Sources */,
 				DE3D0A592A0FA32E00EF23CB /* Exercise.swift in Sources */,
+				4BABEACC69B447A08CA81F27 /* MuscleGroup.swift in Sources */,
+				2D21FFB1F5184D1E9CB843A3 /* Equipment.swift in Sources */,
+				D788CADED88E486B9222A152 /* ExerciseCategory.swift in Sources */,
+				D3266F3A00B24EA3A0939313 /* ExerciseLevel.swift in Sources */,
+				F032F7635E3744C0A7321770 /* ExerciseForce.swift in Sources */,
+				5868170268BF42338B076B4D /* ExerciseMechanic.swift in Sources */,
+				4E3CB142D4B14C51AEAB284A /* ExerciseDefinition.swift in Sources */,
+				299DF74DE6CD41EA89466C26 /* APIClient.swift in Sources */,
+				C3F2A70F91DF497385402FD9 /* Endpoint.swift in Sources */,
+				1421F40CEFEF4CEC9960C718 /* PaginatedResponse.swift in Sources */,
+				79118A677BBC48769758007F /* NetworkError.swift in Sources */,
+				277B3614B7CC4848B1F86532 /* ExerciseDefinitionRepository.swift in Sources */,
+				4A7A0CE9E32F4B3BADE8B1E2 /* ExerciseDefinitionDetailView.swift in Sources */,
 				DEE2FBF02A1A2BB50062437A /* PerformedExercise.swift in Sources */,
 				DE63022B2A2B32DC00BA5E54 /* AddExerciseView.swift in Sources */,
 				DEF951A92A27887800D80381 /* WorkoutTemplateBuilderViewModel.swift in Sources */,
@@ -755,7 +818,6 @@
 				DE1052492A06AF9800399C2B /* HealthKitManager.swift in Sources */,
 				DED4576E2A1E704500066DAE /* Message.swift in Sources */,
 				DEA431C829D8B7C600DFA6E4 /* RoundedButtonStyle.swift in Sources */,
-
 				DE33540129F08420002D4891 /* DependencyContainer.swift in Sources */,
 				DE1E5CD62EFB541100EF4D55 /* WorkoutAppApp.swift in Sources */,
 				DE3353FC29F07F3D002D4891 /* AccountStatus.swift in Sources */,

--- a/WorkoutApp/WorkoutApp/DataLayer/DataTransferObjects/ExerciseDTO.swift
+++ b/WorkoutApp/WorkoutApp/DataLayer/DataTransferObjects/ExerciseDTO.swift
@@ -11,35 +11,34 @@ import SwiftData
 @Model
 class ExerciseDTO: DomainConvertible {
     @Attribute(.unique) var id: UUID
-    var name: String
+    var definition: ExerciseDefinition
     var numberOfSets: Int
     var setData: ExerciseSet
     var restBetweenSets: TimeInterval
     @Relationship(inverse: \WorkoutDTO.exercises) var workouts: [WorkoutDTO]?
-    
-    init(id: UUID, name: String, numberOfSets: Int, setData: ExerciseSet, restBetweenSets: TimeInterval) {
+
+    init(id: UUID, definition: ExerciseDefinition, numberOfSets: Int, setData: ExerciseSet, restBetweenSets: TimeInterval) {
         self.id = id
-        self.name = name
+        self.definition = definition
         self.numberOfSets = numberOfSets
         self.setData = setData
         self.restBetweenSets = restBetweenSets
     }
-    
+
     convenience init(from exercise: Exercise) {
         self.init(
             id: exercise.id,
-            name: exercise.name,
+            definition: exercise.definition,
             numberOfSets: exercise.numberOfSets,
             setData: exercise.setData,
             restBetweenSets: exercise.restBetweenSets
         )
     }
-    
+
     func toDomain() -> Exercise {
-        // Only convert owned properties, NOT inverse relationships (workouts)
         Exercise(
             id: id,
-            name: name,
+            definition: definition,
             numberOfSets: numberOfSets,
             setData: setData,
             restBetweenSets: restBetweenSets

--- a/WorkoutApp/WorkoutApp/DataLayer/DataTransferObjects/ExerciseDefinitionDTO.swift
+++ b/WorkoutApp/WorkoutApp/DataLayer/DataTransferObjects/ExerciseDefinitionDTO.swift
@@ -1,0 +1,89 @@
+//
+//  ExerciseDefinitionDTO.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+class ExerciseDefinitionDTO: DomainConvertible {
+
+    // MARK: - Properties
+    @Attribute(.unique) var id: String
+    var name: String
+    var force: ExerciseForce?
+    var level: ExerciseLevel
+    var mechanic: ExerciseMechanic?
+    var equipment: Equipment?
+    var primaryMuscles: [MuscleGroup]
+    var secondaryMuscles: [MuscleGroup]
+    var instructions: [String]
+    var category: ExerciseCategory
+    var images: [String]
+    var lastSyncedAt: Date
+
+    // MARK: - Initializers
+    init(
+        id: String,
+        name: String,
+        force: ExerciseForce?,
+        level: ExerciseLevel,
+        mechanic: ExerciseMechanic?,
+        equipment: Equipment?,
+        primaryMuscles: [MuscleGroup],
+        secondaryMuscles: [MuscleGroup],
+        instructions: [String],
+        category: ExerciseCategory,
+        images: [String],
+        lastSyncedAt: Date = .now
+    ) {
+        self.id = id
+        self.name = name
+        self.force = force
+        self.level = level
+        self.mechanic = mechanic
+        self.equipment = equipment
+        self.primaryMuscles = primaryMuscles
+        self.secondaryMuscles = secondaryMuscles
+        self.instructions = instructions
+        self.category = category
+        self.images = images
+        self.lastSyncedAt = lastSyncedAt
+    }
+
+    convenience init(from definition: ExerciseDefinition) {
+        self.init(
+            id: definition.id,
+            name: definition.name,
+            force: definition.force,
+            level: definition.level,
+            mechanic: definition.mechanic,
+            equipment: definition.equipment,
+            primaryMuscles: definition.primaryMuscles,
+            secondaryMuscles: definition.secondaryMuscles,
+            instructions: definition.instructions,
+            category: definition.category,
+            images: definition.images
+        )
+    }
+
+    // MARK: - DomainConvertible
+    func toDomain() -> ExerciseDefinition {
+        ExerciseDefinition(
+            id: id,
+            name: name,
+            force: force,
+            level: level,
+            mechanic: mechanic,
+            equipment: equipment,
+            primaryMuscles: primaryMuscles,
+            secondaryMuscles: secondaryMuscles,
+            instructions: instructions,
+            category: category,
+            images: images
+        )
+    }
+}

--- a/WorkoutApp/WorkoutApp/DataLayer/Repositories/ExerciseDefinitionRepository.swift
+++ b/WorkoutApp/WorkoutApp/DataLayer/Repositories/ExerciseDefinitionRepository.swift
@@ -1,0 +1,123 @@
+//
+//  ExerciseDefinitionRepository.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Combine
+import Foundation
+import SwiftData
+
+// MARK: - Protocol
+protocol ExerciseDefinitionRepositoryProtocol {
+    var definitionsPublisher: AnyPublisher<[ExerciseDefinition], Never> { get }
+    func loadDefinitions(muscle: MuscleGroup?, equipment: Equipment?,
+                         category: ExerciseCategory?, page: Int) async throws
+    func search(query: String) async throws -> [ExerciseDefinition]
+    func getDefinition(id: String) async throws -> ExerciseDefinition?
+}
+
+// MARK: - Live Implementation
+class ExerciseDefinitionRepository: ExerciseDefinitionRepositoryProtocol {
+
+    // MARK: - Properties
+    private let apiClient: any APIClientProtocol
+    private let swiftDataManager: SwiftDataManager
+    private let definitionsSubject = CurrentValueSubject<[ExerciseDefinition], Never>([])
+    private let logger = CustomLogger(
+        subsystem: Bundle.main.bundleIdentifier ?? "WorkoutApp",
+        category: "ExerciseDefinitionRepository"
+    )
+
+    var definitionsPublisher: AnyPublisher<[ExerciseDefinition], Never> {
+        definitionsSubject.eraseToAnyPublisher()
+    }
+
+    // MARK: - Initializers
+    init(apiClient: any APIClientProtocol, swiftDataManager: SwiftDataManager = .shared) {
+        self.apiClient = apiClient
+        self.swiftDataManager = swiftDataManager
+    }
+
+    // MARK: - Public Methods
+    func loadDefinitions(muscle: MuscleGroup? = nil, equipment: Equipment? = nil,
+                         category: ExerciseCategory? = nil, page: Int = 0) async throws {
+        // Emit cached data first
+        let cached: [ExerciseDefinitionDTO] = try await swiftDataManager.fetchAll()
+        if !cached.isEmpty {
+            definitionsSubject.send(cached.map { $0.toDomain() })
+        }
+
+        // Fetch from API
+        let endpoint = Endpoint.exercises(muscle: muscle, equipment: equipment, category: category, page: page)
+        let response: PaginatedResponse<ExerciseDefinition> = try await apiClient.request(endpoint)
+        logger.info("Fetched \(response.content.count) definitions from API (page \(page)/\(response.totalPages))")
+
+        // Cache results
+        for definition in response.content {
+            let dto = ExerciseDefinitionDTO(from: definition)
+            try await swiftDataManager.save(dto)
+        }
+
+        // Re-emit with fresh data
+        let updated: [ExerciseDefinitionDTO] = try await swiftDataManager.fetchAll()
+        definitionsSubject.send(updated.map { $0.toDomain() })
+    }
+
+    func search(query: String) async throws -> [ExerciseDefinition] {
+        let endpoint = Endpoint.searchExercises(query: query)
+        let response: PaginatedResponse<ExerciseDefinition> = try await apiClient.request(endpoint)
+        logger.info("Search '\(query)' returned \(response.content.count) results")
+        return response.content
+    }
+
+    func getDefinition(id: String) async throws -> ExerciseDefinition? {
+        let endpoint = Endpoint.exercise(id: id)
+        let definition: ExerciseDefinition = try await apiClient.request(endpoint)
+        return definition
+    }
+}
+
+// MARK: - Mocked Implementation
+class MockedExerciseDefinitionRepository: ExerciseDefinitionRepositoryProtocol {
+
+    // MARK: - Properties
+    private let definitionsSubject = CurrentValueSubject<[ExerciseDefinition], Never>([])
+
+    var definitionsPublisher: AnyPublisher<[ExerciseDefinition], Never> {
+        definitionsSubject.eraseToAnyPublisher()
+    }
+
+    private let mockDefinitions: [ExerciseDefinition] = [
+        .mockedBBBenchPress,
+        .mockedBBSquats,
+        .mockedPullUp,
+    ]
+
+    // MARK: - Public Methods
+    func loadDefinitions(muscle: MuscleGroup? = nil, equipment: Equipment? = nil,
+                         category: ExerciseCategory? = nil, page: Int = 0) async throws {
+        var filtered = mockDefinitions
+
+        if let muscle {
+            filtered = filtered.filter { $0.primaryMuscles.contains(muscle) }
+        }
+        if let equipment {
+            filtered = filtered.filter { $0.equipment == equipment }
+        }
+        if let category {
+            filtered = filtered.filter { $0.category == category }
+        }
+
+        definitionsSubject.send(filtered)
+    }
+
+    func search(query: String) async throws -> [ExerciseDefinition] {
+        mockDefinitions.filter { $0.name.localizedStandardContains(query) }
+    }
+
+    func getDefinition(id: String) async throws -> ExerciseDefinition? {
+        mockDefinitions.first { $0.id == id }
+    }
+}

--- a/WorkoutApp/WorkoutApp/DataLayer/Repositories/ExerciseRepository.swift
+++ b/WorkoutApp/WorkoutApp/DataLayer/Repositories/ExerciseRepository.swift
@@ -70,6 +70,6 @@ class MockedExerciseRepository: ExerciseRepositoryProtocol {
 extension Exercise: SwiftDataConvertible {
 
     var dto: ExerciseDTO {
-        ExerciseDTO(id: id, name: name, numberOfSets: numberOfSets, setData: setData, restBetweenSets: restBetweenSets)
+        ExerciseDTO(id: id, definition: definition, numberOfSets: numberOfSets, setData: setData, restBetweenSets: restBetweenSets)
     }
 }

--- a/WorkoutApp/WorkoutApp/DataLayer/SwiftDataManager.swift
+++ b/WorkoutApp/WorkoutApp/DataLayer/SwiftDataManager.swift
@@ -34,6 +34,7 @@ actor SwiftDataManager {
             WorkoutDTO.self,
             ExerciseDTO.self,
             WorkoutSessionDTO.self,
+            ExerciseDefinitionDTO.self,
         ])
         
         

--- a/WorkoutApp/WorkoutApp/Flows/Main/MainCoordinator.swift
+++ b/WorkoutApp/WorkoutApp/Flows/Main/MainCoordinator.swift
@@ -33,6 +33,7 @@ struct MainCoordinatorView: View {
                 NavigationStack(path: $workoutTemplatesNavigationManager.path) {
                     WorkoutTemplatesListWrapper(
                         exerciseRepository: dependencyContainer.exerciseRepository,
+                        exerciseDefinitionRepository: dependencyContainer.exerciseDefinitionRepository,
                         workoutTemplateRepository: dependencyContainer.workoutTemplateRepository,
                         navigationManager: workoutTemplatesNavigationManager
                     )
@@ -73,12 +74,14 @@ private struct HomeWrapper: View {
 private struct WorkoutTemplatesListWrapper: View {
 
     let exerciseRepository: any ExerciseRepositoryProtocol
+    let exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol
     let workoutTemplateRepository: any WorkoutRepository
     let navigationManager: WorkoutTemplatesNavigationManager
     @State private var viewModel: WorkoutTemplatesList.ViewModel
 
-    init(exerciseRepository: any ExerciseRepositoryProtocol, workoutTemplateRepository: any WorkoutRepository, navigationManager: WorkoutTemplatesNavigationManager) {
+    init(exerciseRepository: any ExerciseRepositoryProtocol, exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol, workoutTemplateRepository: any WorkoutRepository, navigationManager: WorkoutTemplatesNavigationManager) {
         self.exerciseRepository = exerciseRepository
+        self.exerciseDefinitionRepository = exerciseDefinitionRepository
         self.workoutTemplateRepository = workoutTemplateRepository
         self.navigationManager = navigationManager
         self._viewModel = State(wrappedValue: WorkoutTemplatesList.ViewModel(
@@ -92,6 +95,7 @@ private struct WorkoutTemplatesListWrapper: View {
             .navigationDestination(for: WorkoutTemplateBuilderRoute.self) { route in
                 WorkoutTemplateBuilderWrapper(
                     exerciseRepository: exerciseRepository,
+                    exerciseDefinitionRepository: exerciseDefinitionRepository,
                     workoutTemplateRepository: workoutTemplateRepository,
                     navigationManager: navigationManager,
                     route: route
@@ -102,16 +106,19 @@ private struct WorkoutTemplatesListWrapper: View {
 
 private struct WorkoutTemplateBuilderWrapper: View {
     let exerciseRepository: any ExerciseRepositoryProtocol
+    let exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol
     let workoutTemplateRepository: any WorkoutRepository
     let navigationManager: WorkoutTemplatesNavigationManager
     @State private var viewModel: WorkoutTemplateBuilder.ViewModel
 
-    init(exerciseRepository: any ExerciseRepositoryProtocol, workoutTemplateRepository: any WorkoutRepository, navigationManager: WorkoutTemplatesNavigationManager, route: WorkoutTemplateBuilderRoute) {
+    init(exerciseRepository: any ExerciseRepositoryProtocol, exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol, workoutTemplateRepository: any WorkoutRepository, navigationManager: WorkoutTemplatesNavigationManager, route: WorkoutTemplateBuilderRoute) {
         self.exerciseRepository = exerciseRepository
+        self.exerciseDefinitionRepository = exerciseDefinitionRepository
         self.workoutTemplateRepository = workoutTemplateRepository
         self.navigationManager = navigationManager
         self._viewModel = State(wrappedValue: WorkoutTemplateBuilder.ViewModel(
             exerciseRepository: exerciseRepository,
+            exerciseDefinitionRepository: exerciseDefinitionRepository,
             workoutTemplateRepository: workoutTemplateRepository,
             navigationManager: navigationManager,
             workout: route.workout

--- a/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/AddExerciseView.swift
+++ b/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/AddExerciseView.swift
@@ -14,159 +14,189 @@ extension AddExerciseView {
     @MainActor
     @Observable class ViewModel {
 
-        var existentExercises = [Exercise]()
-        var newExerciseName = ""
+        // MARK: - Properties
+        var definitions = [ExerciseDefinition]()
+        var searchResults = [ExerciseDefinition]()
+        var searchText = ""
+        var isSearching = false
         var isAddingExercise = false
+        var newExerciseName = ""
         var selectedExercise: Exercise?
         var showEditView = false
+        var selectedDetailDefinition: ExerciseDefinition?
 
+        var selectedMuscle: MuscleGroup?
+        var selectedEquipment: Equipment?
+        var selectedCategory: ExerciseCategory?
+        var isLastPage = false
+        var currentPage = 0
+        var isLoadingMore = false
+
+        var displayedDefinitions: [ExerciseDefinition] {
+            if !searchText.isEmpty {
+                return searchResults
+            }
+            return definitions
+        }
+
+        private let exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol
         private let exerciseRepository: any ExerciseRepositoryProtocol
         private let onExerciseSelected: (Exercise) -> Void
         @ObservationIgnored private var cancellables = Set<AnyCancellable>()
         @ObservationIgnored private var loadTask: Task<Void, Never>?
+        @ObservationIgnored private var searchTask: Task<Void, Never>?
 
-        init(exerciseRepository: any ExerciseRepositoryProtocol, onExerciseSelected: @escaping (Exercise) -> Void) {
+        // MARK: - Initializers
+        init(
+            exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol,
+            exerciseRepository: any ExerciseRepositoryProtocol,
+            onExerciseSelected: @escaping (Exercise) -> Void
+        ) {
+            self.exerciseDefinitionRepository = exerciseDefinitionRepository
             self.exerciseRepository = exerciseRepository
             self.onExerciseSelected = onExerciseSelected
-            subscribeToExercises()
-            loadExercises()
+            subscribeToDefinitions()
+            loadDefinitions()
         }
 
-        //MARK: - Private Methods
-        private func subscribeToExercises() {
-            exerciseRepository
-                .entitiesPublisher
-                .sink { [weak self] exercises in
-                    self?.existentExercises = exercises
+        // MARK: - Private Methods
+        private func subscribeToDefinitions() {
+            exerciseDefinitionRepository
+                .definitionsPublisher
+                .sink { [weak self] definitions in
+                    self?.definitions = definitions
                 }
                 .store(in: &cancellables)
         }
 
-        private func loadExercises() {
+        private func loadDefinitions() {
             loadTask?.cancel()
             loadTask = Task { @MainActor [weak self] in
+                guard let self else { return }
                 do {
-                    try await self?.exerciseRepository.loadData()
+                    try await exerciseDefinitionRepository.loadDefinitions(
+                        muscle: selectedMuscle,
+                        equipment: selectedEquipment,
+                        category: selectedCategory,
+                        page: currentPage
+                    )
                 } catch {
-                    print("Error while loading exercises: \(error.localizedDescription)")
+                    print("Error loading definitions: \(error.localizedDescription)")
                 }
             }
         }
 
-        //MARK: - Handlers
+        // MARK: - Handlers
+        func handleSearchChanged(_ query: String) {
+            searchTask?.cancel()
+            guard !query.isEmpty else {
+                searchResults = []
+                isSearching = false
+                return
+            }
+
+            isSearching = true
+            searchTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                try? await Task.sleep(for: .milliseconds(300))
+                guard !Task.isCancelled else { return }
+
+                do {
+                    searchResults = try await exerciseDefinitionRepository.search(query: query)
+                } catch {
+                    print("Search error: \(error.localizedDescription)")
+                }
+                isSearching = false
+            }
+        }
+
+        func handleFilterChanged() {
+            currentPage = 0
+            isLastPage = false
+            definitions = []
+            loadDefinitions()
+        }
+
+        func handleLoadMore() {
+            guard !isLastPage, !isLoadingMore else { return }
+            isLoadingMore = true
+            currentPage += 1
+            loadTask?.cancel()
+            loadTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    try await exerciseDefinitionRepository.loadDefinitions(
+                        muscle: selectedMuscle,
+                        equipment: selectedEquipment,
+                        category: selectedCategory,
+                        page: currentPage
+                    )
+                } catch {
+                    print("Error loading more: \(error.localizedDescription)")
+                }
+                isLoadingMore = false
+            }
+        }
+
+        func handleDefinitionTapped(_ definition: ExerciseDefinition) {
+            let exercise = Exercise(
+                id: .init(),
+                definition: definition,
+                numberOfSets: 3,
+                setData: ExerciseSet(id: .init(), reps: 10),
+                restBetweenSets: 60
+            )
+            selectedExercise = exercise
+            showEditView = true
+        }
+
+        func handleExerciseEdited(_ exercise: Exercise) {
+            onExerciseSelected(exercise)
+        }
+
         func handleAddExerciseTapped() {
             Task(priority: .userInitiated) { [weak self] in
                 guard let self else { return }
                 do {
-                    let exercise = Exercise(id: .init(), name: self.newExerciseName, numberOfSets: 0, setData: .init(id: .init(), reps: 0), restBetweenSets: 0)
+                    let definition = ExerciseDefinition.legacy(name: self.newExerciseName)
+                    let exercise = Exercise(id: .init(), definition: definition, numberOfSets: 0, setData: .init(id: .init(), reps: 0), restBetweenSets: 0)
                     try await self.exerciseRepository.save(entity: exercise)
                     await MainActor.run {
                         self.newExerciseName = ""
                         self.isAddingExercise = false
                     }
-                    print("Successfully added exercise: \(exercise.name)")
                 } catch {
                     print("Error while saving exercise: \(error.localizedDescription)")
                 }
             }
         }
-
-        func handleOnAppear() {
-            loadExercises()
-        }
-        
-        func handleExerciseTapped(for exercise: Exercise) {
-            // IMPORTANT: Reuse existing IDs to prevent duplicates in SwiftData
-            // SwiftData's @Attribute(.unique) will upsert based on these IDs
-            let exerciseForWorkout = Exercise(
-                id: exercise.id,
-                name: exercise.name,
-                numberOfSets: exercise.numberOfSets > 0 ? exercise.numberOfSets : 3,
-                setData: ExerciseSet(
-                    id: exercise.setData.id,
-                    reps: exercise.setData.reps > 0 ? exercise.setData.reps : 10
-                ),
-                restBetweenSets: exercise.restBetweenSets > 0 ? exercise.restBetweenSets : 60
-            )
-            selectedExercise = exerciseForWorkout
-            showEditView = true
-        }
-        
-        func handleExerciseEdited(_ exercise: Exercise) {
-            onExerciseSelected(exercise)
-        }
     }
 }
 
 struct AddExerciseView: View {
-    
+
     @State private var viewModel: ViewModel
-    @State private var searchText = ""
     @Environment(\.dismiss) private var dismiss
-    
-    init(exerciseRepository: any ExerciseRepositoryProtocol, onExerciseSelected: @escaping (Exercise) -> Void) {
-        self._viewModel = .init(wrappedValue: ViewModel(exerciseRepository: exerciseRepository, onExerciseSelected: onExerciseSelected))
+
+    init(
+        exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol,
+        exerciseRepository: any ExerciseRepositoryProtocol,
+        onExerciseSelected: @escaping (Exercise) -> Void
+    ) {
+        self._viewModel = .init(wrappedValue: ViewModel(
+            exerciseDefinitionRepository: exerciseDefinitionRepository,
+            exerciseRepository: exerciseRepository,
+            onExerciseSelected: onExerciseSelected
+        ))
     }
-    
-    var filteredExercises: [Exercise] {
-        if searchText.isEmpty {
-            return viewModel.existentExercises
-        }
-        return viewModel.existentExercises.filter { exercise in
-            exercise.name.localizedStandardContains(searchText)
-        }
-    }
-    
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                // Search bar
-                TextField("Search exercises", text: $searchText)
-                    .textFieldStyle(.roundedBorder)
-                    .padding()
-                
-                // Exercises list
-                if filteredExercises.isEmpty && !searchText.isEmpty {
-                    ContentUnavailableView(
-                        "No exercises found",
-                        systemImage: "magnifyingglass",
-                        description: Text("Try a different search term")
-                    )
-                } else {
-                    List {
-                        ForEach(filteredExercises) { exercise in
-                            Button {
-                                viewModel.handleExerciseTapped(for: exercise)
-                            } label: {
-                                HStack {
-                                    Image(systemName: "figure.strengthtraining.traditional")
-                                        .foregroundStyle(Color.primaryColor)
-                                    
-                                    Text(exercise.name)
-                                        .foregroundStyle(.primary)
-                                    
-                                    Spacer()
-                                    
-                                    Image(systemName: "plus.circle.fill")
-                                        .foregroundStyle(Color.primaryColor)
-                                }
-                            }
-                        }
-                    }
-                    .listStyle(.plain)
-                }
-                
-                // Add new exercise button
-                Divider()
-                
-                Button {
-                    viewModel.isAddingExercise = true
-                } label: {
-                    Label("Create New Exercise", systemImage: "plus.circle")
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                }
-                .buttonStyle(.bordered)
+                searchBar
+                filterChips
+                definitionsList
+                createExerciseButton
             }
             .navigationTitle("Add Exercise")
             .navigationBarTitleDisplayMode(.inline)
@@ -192,17 +222,239 @@ struct AddExerciseView: View {
                     )
                 }
             }
-            .onAppear {
-                viewModel.handleOnAppear()
+            .sheet(item: $viewModel.selectedDetailDefinition) { definition in
+                ExerciseDefinitionDetailView(definition: definition)
             }
         }
     }
 }
 
+// MARK: - Search Bar
+private extension AddExerciseView {
+    var searchBar: some View {
+        TextField("Search exercises", text: $viewModel.searchText)
+            .textFieldStyle(.roundedBorder)
+            .padding()
+            .onChange(of: viewModel.searchText) { _, newValue in
+                viewModel.handleSearchChanged(newValue)
+            }
+    }
+}
+
+// MARK: - Filter Chips
+private extension AddExerciseView {
+    var filterChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                FilterMenu(
+                    title: "Muscle",
+                    selection: $viewModel.selectedMuscle,
+                    options: MuscleGroup.allCases
+                )
+
+                FilterMenu(
+                    title: "Equipment",
+                    selection: $viewModel.selectedEquipment,
+                    options: Equipment.allCases
+                )
+
+                FilterMenu(
+                    title: "Category",
+                    selection: $viewModel.selectedCategory,
+                    options: ExerciseCategory.allCases
+                )
+
+                if viewModel.selectedMuscle != nil || viewModel.selectedEquipment != nil || viewModel.selectedCategory != nil {
+                    Button("Clear", role: .destructive) {
+                        viewModel.selectedMuscle = nil
+                        viewModel.selectedEquipment = nil
+                        viewModel.selectedCategory = nil
+                        viewModel.handleFilterChanged()
+                    }
+                    .font(.caption)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+        }
+    }
+}
+
+// MARK: - Definitions List
+private extension AddExerciseView {
+    var definitionsList: some View {
+        Group {
+            if viewModel.displayedDefinitions.isEmpty && !viewModel.searchText.isEmpty {
+                ContentUnavailableView(
+                    "No exercises found",
+                    systemImage: "magnifyingglass",
+                    description: Text("Try a different search term or filter")
+                )
+            } else {
+                List {
+                    ForEach(viewModel.displayedDefinitions) { definition in
+                        Button {
+                            viewModel.handleDefinitionTapped(definition)
+                        } label: {
+                            ExerciseDefinitionRow(
+                                definition: definition,
+                                onInfoTapped: {
+                                    viewModel.selectedDetailDefinition = definition
+                                }
+                            )
+                        }
+                        .onAppear {
+                            if definition.id == viewModel.displayedDefinitions.last?.id {
+                                viewModel.handleLoadMore()
+                            }
+                        }
+                    }
+
+                    if viewModel.isLoadingMore {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                            Spacer()
+                        }
+                        .listRowSeparator(.hidden)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+}
+
+// MARK: - Create Exercise Button
+private extension AddExerciseView {
+    var createExerciseButton: some View {
+        VStack(spacing: 0) {
+            Divider()
+
+            Button {
+                viewModel.isAddingExercise = true
+            } label: {
+                Label("Create New Exercise", systemImage: "plus.circle")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}
+
+// MARK: - ExerciseDefinitionRow
+private struct ExerciseDefinitionRow: View {
+    let definition: ExerciseDefinition
+    let onInfoTapped: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(definition.name)
+                    .font(.body)
+                    .bold()
+                    .foregroundStyle(.primary)
+
+                HStack(spacing: 6) {
+                    ForEach(definition.primaryMuscles, id: \.self) { muscle in
+                        Text(muscle.displayName)
+                            .font(.caption2)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.primaryColor.opacity(0.15))
+                            .clipShape(.capsule)
+                    }
+
+                    if let equipment = definition.equipment {
+                        Text(equipment.displayName)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                HStack(spacing: 4) {
+                    Text(definition.level.displayName)
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(levelColor(definition.level).opacity(0.15))
+                        .foregroundStyle(levelColor(definition.level))
+                        .clipShape(.capsule)
+
+                    Text(definition.category.displayName)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            Spacer()
+
+            Button("Info", systemImage: "info.circle") {
+                onInfoTapped()
+            }
+            .labelStyle(.iconOnly)
+            .foregroundStyle(.secondary)
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func levelColor(_ level: ExerciseLevel) -> Color {
+        switch level {
+        case .beginner: .green
+        case .intermediate: .orange
+        case .expert: .red
+        }
+    }
+}
+
+// MARK: - Filter Menu
+private struct FilterMenu<T: Hashable & CaseIterable & RawRepresentable>: View where T.AllCases: RandomAccessCollection {
+    let title: String
+    @Binding var selection: T?
+    let options: T.AllCases
+
+    var body: some View {
+        Menu {
+            ForEach(options, id: \.self) { option in
+                Button {
+                    selection = option
+                } label: {
+                    if selection == option {
+                        Label(displayName(for: option), systemImage: "checkmark")
+                    } else {
+                        Text(displayName(for: option))
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(selection.map { displayName(for: $0) } ?? title)
+                    .font(.caption)
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(selection != nil ? Color.primaryColor.opacity(0.15) : Color.secondary.opacity(0.1))
+            .foregroundStyle(selection != nil ? Color.primaryColor : .secondary)
+            .clipShape(.capsule)
+        }
+    }
+
+    private func displayName(for option: T) -> String {
+        if let muscle = option as? MuscleGroup { return muscle.displayName }
+        if let equipment = option as? Equipment { return equipment.displayName }
+        if let category = option as? ExerciseCategory { return category.displayName }
+        return String(describing: option)
+    }
+}
+
+// MARK: - Add New Exercise Sheet
 private struct AddNewExerciseSheet: View {
     @Bindable var viewModel: AddExerciseView.ViewModel
     @Environment(\.dismiss) private var dismiss
-    
+
     var body: some View {
         NavigationStack {
             Form {
@@ -217,7 +469,7 @@ private struct AddNewExerciseSheet: View {
                         dismiss()
                     }
                 }
-                
+
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add") {
                         viewModel.handleAddExerciseTapped()
@@ -231,17 +483,18 @@ private struct AddNewExerciseSheet: View {
     }
 }
 
+// MARK: - Edit Exercise Sheet Wrapper
 private struct EditExerciseSheetWrapper: View {
     let exercise: Exercise
     let onFinishedEditing: (Exercise) -> Void
     @State private var editedExercise: Exercise
-    
+
     init(exercise: Exercise, onFinishedEditing: @escaping (Exercise) -> Void) {
         self.exercise = exercise
         self.onFinishedEditing = onFinishedEditing
         _editedExercise = State(initialValue: exercise)
     }
-    
+
     var body: some View {
         EditView(
             exercise: $editedExercise,
@@ -252,8 +505,10 @@ private struct EditExerciseSheetWrapper: View {
     }
 }
 
-struct AddExerciseView_Previews: PreviewProvider {
-    static var previews: some View {
-        AddExerciseView(exerciseRepository: MockedExerciseRepository(), onExerciseSelected: { _ in })
-    }
+#Preview {
+    AddExerciseView(
+        exerciseDefinitionRepository: MockedExerciseDefinitionRepository(),
+        exerciseRepository: MockedExerciseRepository(),
+        onExerciseSelected: { _ in }
+    )
 }

--- a/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/EditView.swift
+++ b/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/EditView.swift
@@ -31,7 +31,7 @@ struct EditView: View {
             
             let exercise = Exercise(
                 id: exercise.wrappedValue.id,
-                name: exercise.wrappedValue.name,
+                definition: exercise.wrappedValue.definition,
                 numberOfSets: Int(newSets) ?? 0,
                 setData: .init(
                     id: exercise.wrappedValue.setData.id,

--- a/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/ExerciseDefinitionDetailView.swift
+++ b/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/ExerciseDefinitionDetailView.swift
@@ -1,0 +1,274 @@
+//
+//  ExerciseDefinitionDetailView.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import SwiftUI
+
+struct ExerciseDefinitionDetailView: View {
+
+    // MARK: - Properties
+    let definition: ExerciseDefinition
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Body
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    badgesSection
+                    musclesSection
+                    equipmentSection
+                    instructionsSection
+                    imageGallery
+                }
+                .padding()
+            }
+            .background(Color.background)
+            .navigationTitle(definition.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Badges Section
+private extension ExerciseDefinitionDetailView {
+    var badgesSection: some View {
+        HStack(spacing: 8) {
+            Badge(text: definition.category.displayName, color: .primaryColor)
+            Badge(text: definition.level.displayName, color: levelColor)
+
+            if let force = definition.force {
+                Badge(text: force.displayName, color: .secondary)
+            }
+            if let mechanic = definition.mechanic {
+                Badge(text: mechanic.displayName, color: .secondary)
+            }
+        }
+    }
+
+    var levelColor: Color {
+        switch definition.level {
+        case .beginner: .green
+        case .intermediate: .orange
+        case .expert: .red
+        }
+    }
+}
+
+// MARK: - Muscles Section
+private extension ExerciseDefinitionDetailView {
+    var musclesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if !definition.primaryMuscles.isEmpty {
+                MuscleTagGroup(title: "Primary Muscles", muscles: definition.primaryMuscles, isPrimary: true)
+            }
+            if !definition.secondaryMuscles.isEmpty {
+                MuscleTagGroup(title: "Secondary Muscles", muscles: definition.secondaryMuscles, isPrimary: false)
+            }
+        }
+    }
+}
+
+// MARK: - Equipment Section
+private extension ExerciseDefinitionDetailView {
+    @ViewBuilder
+    var equipmentSection: some View {
+        if let equipment = definition.equipment {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Equipment")
+                    .font(.subheadline)
+                    .bold()
+                    .foregroundStyle(Color.onBackground)
+
+                HStack(spacing: 6) {
+                    Image(systemName: "dumbbell")
+                        .foregroundStyle(Color.primaryColor)
+                    Text(equipment.displayName)
+                        .foregroundStyle(Color.onBackground)
+                }
+                .font(.body)
+            }
+        }
+    }
+}
+
+// MARK: - Instructions Section
+private extension ExerciseDefinitionDetailView {
+    @ViewBuilder
+    var instructionsSection: some View {
+        if !definition.instructions.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Instructions")
+                    .font(.subheadline)
+                    .bold()
+                    .foregroundStyle(Color.onBackground)
+
+                ForEach(definition.instructions.enumerated(), id: \.element) { index, instruction in
+                    HStack(alignment: .top, spacing: 10) {
+                        Text("\(index + 1)")
+                            .font(.caption)
+                            .bold()
+                            .foregroundStyle(.white)
+                            .frame(width: 24, height: 24)
+                            .background(Color.primaryColor)
+                            .clipShape(.circle)
+
+                        Text(instruction)
+                            .font(.body)
+                            .foregroundStyle(Color.onBackground)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Image Gallery
+private extension ExerciseDefinitionDetailView {
+    @ViewBuilder
+    var imageGallery: some View {
+        if !definition.images.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Images")
+                    .font(.subheadline)
+                    .bold()
+                    .foregroundStyle(Color.onBackground)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(definition.images, id: \.self) { imageURL in
+                            AsyncImage(url: URL(string: imageURL)) { phase in
+                                switch phase {
+                                case .success(let image):
+                                    image
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(width: 200, height: 200)
+                                        .clipShape(.rect(cornerRadius: 12))
+                                case .failure:
+                                    imagePlaceholder
+                                case .empty:
+                                    ProgressView()
+                                        .frame(width: 200, height: 200)
+                                @unknown default:
+                                    imagePlaceholder
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    var imagePlaceholder: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(Color.surface)
+            .frame(width: 200, height: 200)
+            .overlay {
+                Image(systemName: "photo")
+                    .font(.largeTitle)
+                    .foregroundStyle(.tertiary)
+            }
+    }
+}
+
+// MARK: - Badge
+private struct Badge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .bold()
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(.capsule)
+    }
+}
+
+// MARK: - Muscle Tag Group
+private struct MuscleTagGroup: View {
+    let title: String
+    let muscles: [MuscleGroup]
+    let isPrimary: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.subheadline)
+                .bold()
+                .foregroundStyle(Color.onBackground)
+
+            FlowLayout(spacing: 6) {
+                ForEach(muscles, id: \.self) { muscle in
+                    Text(muscle.displayName)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(isPrimary ? Color.primaryColor.opacity(0.15) : Color.secondary.opacity(0.1))
+                        .foregroundStyle(isPrimary ? Color.primaryColor : .secondary)
+                        .clipShape(.capsule)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Flow Layout
+private struct FlowLayout: Layout {
+    let spacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = arrange(proposal: proposal, subviews: subviews)
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y), proposal: .unspecified)
+        }
+    }
+
+    private func arrange(proposal: ProposedViewSize, subviews: Subviews) -> (size: CGSize, positions: [CGPoint]) {
+        let maxWidth = proposal.width ?? .infinity
+        var positions = [CGPoint]()
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var maxX: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if currentX + size.width > maxWidth, currentX > 0 {
+                currentX = 0
+                currentY += lineHeight + spacing
+                lineHeight = 0
+            }
+            positions.append(CGPoint(x: currentX, y: currentY))
+            lineHeight = max(lineHeight, size.height)
+            currentX += size.width + spacing
+            maxX = max(maxX, currentX - spacing)
+        }
+
+        return (CGSize(width: maxX, height: currentY + lineHeight), positions)
+    }
+}
+
+#Preview {
+    ExerciseDefinitionDetailView(definition: .mockedBBBenchPress)
+}

--- a/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/WorkoutTemplateBuilderView.swift
+++ b/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/WorkoutTemplateBuilderView.swift
@@ -46,6 +46,7 @@ struct WorkoutTemplateBuilder {
             }
             .sheet(isPresented: $viewModel.showAddExerciseView) {
                 AddExerciseView(
+                    exerciseDefinitionRepository: viewModel.exerciseDefinitionRepository,
                     exerciseRepository: viewModel.exerciseRepository,
                     onExerciseSelected: { exercise in
                         viewModel.exercises.append(exercise)
@@ -188,6 +189,7 @@ struct WorkoutTemplateBuilder {
         WorkoutTemplateBuilder.ContentView(
             viewModel: .init(
                 exerciseRepository: MockedExerciseRepository(),
+                exerciseDefinitionRepository: MockedExerciseDefinitionRepository(),
                 workoutTemplateRepository: MockedWorkoutRepository(),
                 navigationManager: WorkoutTemplatesNavigationManager(),
                 workout: nil
@@ -206,6 +208,7 @@ private struct WorkoutTemplateBuilderPreviewWithExercises: View {
     init() {
         viewModel = WorkoutTemplateBuilder.ViewModel(
             exerciseRepository: MockedExerciseRepository(),
+            exerciseDefinitionRepository: MockedExerciseDefinitionRepository(),
             workoutTemplateRepository: MockedWorkoutRepository(),
             navigationManager: WorkoutTemplatesNavigationManager(),
             workout: nil

--- a/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/WorkoutTemplateBuilderViewModel.swift
+++ b/WorkoutApp/WorkoutApp/Flows/Main/WorkoutTemplates/WorkoutTemplateBuilder/WorkoutTemplateBuilderViewModel.swift
@@ -29,6 +29,7 @@ extension WorkoutTemplateBuilder {
         var exercises = [Exercise]()
 
         let exerciseRepository: any ExerciseRepositoryProtocol
+        let exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol
         let workoutTemplateRepository: any WorkoutRepository
 
         var workout: Workout?
@@ -49,10 +50,12 @@ extension WorkoutTemplateBuilder {
 
         //MARK: - Initializers
         init(exerciseRepository: any ExerciseRepositoryProtocol,
+             exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol,
              workoutTemplateRepository: any WorkoutRepository,
              navigationManager: WorkoutTemplatesNavigationManager,
              workout: Workout? = nil) {
             self.exerciseRepository = exerciseRepository
+            self.exerciseDefinitionRepository = exerciseDefinitionRepository
             self.workoutTemplateRepository = workoutTemplateRepository
             self.navigationManager = navigationManager
             self.workout = workout

--- a/WorkoutApp/WorkoutApp/Model/Equipment.swift
+++ b/WorkoutApp/WorkoutApp/Model/Equipment.swift
@@ -1,0 +1,35 @@
+//
+//  Equipment.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+enum Equipment: String, Codable, CaseIterable, Hashable {
+    case barbell
+    case dumbbell
+    case cable
+    case machine
+    case kettlebells
+    case bands
+    case bodyOnly = "body only"
+    case medicineBall = "medicine ball"
+    case exerciseBall = "exercise ball"
+    case ezCurlBar = "e-z curl bar"
+    case foamRoll = "foam roll"
+    case other
+
+    // MARK: - Properties
+    var displayName: String {
+        switch self {
+        case .bodyOnly: "Body Only"
+        case .medicineBall: "Medicine Ball"
+        case .exerciseBall: "Exercise Ball"
+        case .ezCurlBar: "E-Z Curl Bar"
+        case .foamRoll: "Foam Roll"
+        default: rawValue.capitalized
+        }
+    }
+}

--- a/WorkoutApp/WorkoutApp/Model/Exercise.swift
+++ b/WorkoutApp/WorkoutApp/Model/Exercise.swift
@@ -8,31 +8,71 @@
 import Foundation
 
 struct Exercise: Identifiable, Codable, Hashable {
-    
+
     let id: UUID
-    let name: String
+    let definition: ExerciseDefinition
     let numberOfSets: Int
     let setData: ExerciseSet
-    
     let restBetweenSets: TimeInterval
+
+    // MARK: - Convenience Accessors
+    var name: String { definition.name }
+
+    // MARK: - Codable
+    enum CodingKeys: String, CodingKey {
+        case id, definition, name, numberOfSets, setData, restBetweenSets
+    }
+
+    init(id: UUID, definition: ExerciseDefinition, numberOfSets: Int, setData: ExerciseSet, restBetweenSets: TimeInterval) {
+        self.id = id
+        self.definition = definition
+        self.numberOfSets = numberOfSets
+        self.setData = setData
+        self.restBetweenSets = restBetweenSets
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+
+        if let definition = try? container.decode(ExerciseDefinition.self, forKey: .definition) {
+            self.definition = definition
+        } else {
+            // Legacy migration: old Exercise had a flat "name" field
+            let legacyName = try container.decode(String.self, forKey: .name)
+            self.definition = ExerciseDefinition.legacy(name: legacyName)
+        }
+
+        numberOfSets = try container.decode(Int.self, forKey: .numberOfSets)
+        setData = try container.decode(ExerciseSet.self, forKey: .setData)
+        restBetweenSets = try container.decode(TimeInterval.self, forKey: .restBetweenSets)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(definition, forKey: .definition)
+        try container.encode(numberOfSets, forKey: .numberOfSets)
+        try container.encode(setData, forKey: .setData)
+        try container.encode(restBetweenSets, forKey: .restBetweenSets)
+    }
 }
 
+// MARK: - Mocked Data
 extension Exercise {
-    
     static let mockedBBBenchPress = Exercise(
         id: .init(),
-        name: "BB Bench Press",
+        definition: .mockedBBBenchPress,
         numberOfSets: 3,
         setData: .mockedBBBenchPress,
         restBetweenSets: 150
     )
-    
+
     static let mockedBBSquats = Exercise(
         id: .init(),
-        name: "BB Squats",
+        definition: .mockedBBSquats,
         numberOfSets: 4,
         setData: .mockedBBSquats,
         restBetweenSets: 150
-
     )
 }

--- a/WorkoutApp/WorkoutApp/Model/ExerciseCategory.swift
+++ b/WorkoutApp/WorkoutApp/Model/ExerciseCategory.swift
@@ -1,0 +1,26 @@
+//
+//  ExerciseCategory.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+enum ExerciseCategory: String, Codable, CaseIterable, Hashable {
+    case strength
+    case stretching
+    case cardio
+    case powerlifting
+    case plyometrics
+    case strongman
+    case olympicWeightlifting = "olympic weightlifting"
+
+    // MARK: - Properties
+    var displayName: String {
+        switch self {
+        case .olympicWeightlifting: "Olympic Weightlifting"
+        default: rawValue.capitalized
+        }
+    }
+}

--- a/WorkoutApp/WorkoutApp/Model/ExerciseDefinition.swift
+++ b/WorkoutApp/WorkoutApp/Model/ExerciseDefinition.swift
@@ -1,0 +1,101 @@
+//
+//  ExerciseDefinition.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+struct ExerciseDefinition: Identifiable, Codable, Hashable {
+    let id: String
+    let name: String
+    let force: ExerciseForce?
+    let level: ExerciseLevel
+    let mechanic: ExerciseMechanic?
+    let equipment: Equipment?
+    let primaryMuscles: [MuscleGroup]
+    let secondaryMuscles: [MuscleGroup]
+    let instructions: [String]
+    let category: ExerciseCategory
+    let images: [String]
+}
+
+// MARK: - Legacy Support
+extension ExerciseDefinition {
+    static func legacy(name: String) -> ExerciseDefinition {
+        ExerciseDefinition(
+            id: UUID().uuidString,
+            name: name,
+            force: nil,
+            level: .beginner,
+            mechanic: nil,
+            equipment: nil,
+            primaryMuscles: [],
+            secondaryMuscles: [],
+            instructions: [],
+            category: .strength,
+            images: []
+        )
+    }
+}
+
+// MARK: - Mocked Data
+extension ExerciseDefinition {
+    static let mockedBBBenchPress = ExerciseDefinition(
+        id: "barbell_bench_press",
+        name: "Barbell Bench Press",
+        force: .push,
+        level: .intermediate,
+        mechanic: .compound,
+        equipment: .barbell,
+        primaryMuscles: [.chest],
+        secondaryMuscles: [.shoulders, .triceps],
+        instructions: [
+            "Lie back on a flat bench. Using a medium width grip, lift the bar from the rack and hold it straight over you with your arms locked.",
+            "From the starting position, breathe in and begin coming down slowly until the bar touches your middle chest.",
+            "After a brief pause, push the bar back to the starting position as you breathe out. Lock your arms and squeeze your chest in the contracted position, hold for a second and then start coming down slowly again.",
+            "Repeat the movement for the prescribed amount of repetitions."
+        ],
+        category: .strength,
+        images: ["barbell_bench_press_1", "barbell_bench_press_2"]
+    )
+
+    static let mockedBBSquats = ExerciseDefinition(
+        id: "barbell_squat",
+        name: "Barbell Squat",
+        force: .push,
+        level: .intermediate,
+        mechanic: .compound,
+        equipment: .barbell,
+        primaryMuscles: [.quadriceps],
+        secondaryMuscles: [.hamstrings, .glutes, .calves, .lowerBack],
+        instructions: [
+            "Set up a barbell on a squat rack at about shoulder height. Step under the bar and place it across your upper back.",
+            "Lift the bar off the rack by pushing with your legs and straightening your torso. Step away from the rack with your feet shoulder-width apart.",
+            "Begin to slowly lower the bar by bending the knees as you maintain a straight posture. Continue down until your thighs are parallel to the floor.",
+            "Raise the bar back to the starting position by pushing through your heels as you straighten your legs."
+        ],
+        category: .strength,
+        images: ["barbell_squat_1", "barbell_squat_2"]
+    )
+
+    static let mockedPullUp = ExerciseDefinition(
+        id: "pullup",
+        name: "Pull-Up",
+        force: .pull,
+        level: .intermediate,
+        mechanic: .compound,
+        equipment: .bodyOnly,
+        primaryMuscles: [.lats],
+        secondaryMuscles: [.biceps, .middleBack],
+        instructions: [
+            "Grab the pull-up bar with the palms facing forward using a wide grip.",
+            "With both arms extended in front of you holding the bar, bring your torso back around 30 degrees while creating a curvature on your lower back.",
+            "Pull your torso up until the bar touches your upper chest by drawing the shoulders and the upper arms down and back.",
+            "After a second of squeezing at the top, slowly lower your torso back to the starting position."
+        ],
+        category: .strength,
+        images: ["pullup_1", "pullup_2"]
+    )
+}

--- a/WorkoutApp/WorkoutApp/Model/ExerciseForce.swift
+++ b/WorkoutApp/WorkoutApp/Model/ExerciseForce.swift
@@ -1,0 +1,19 @@
+//
+//  ExerciseForce.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+enum ExerciseForce: String, Codable, Hashable {
+    case push
+    case pull
+    case `static`
+
+    // MARK: - Properties
+    var displayName: String {
+        rawValue.capitalized
+    }
+}

--- a/WorkoutApp/WorkoutApp/Model/ExerciseLevel.swift
+++ b/WorkoutApp/WorkoutApp/Model/ExerciseLevel.swift
@@ -1,0 +1,19 @@
+//
+//  ExerciseLevel.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+enum ExerciseLevel: String, Codable, CaseIterable, Hashable {
+    case beginner
+    case intermediate
+    case expert
+
+    // MARK: - Properties
+    var displayName: String {
+        rawValue.capitalized
+    }
+}

--- a/WorkoutApp/WorkoutApp/Model/ExerciseMechanic.swift
+++ b/WorkoutApp/WorkoutApp/Model/ExerciseMechanic.swift
@@ -1,0 +1,18 @@
+//
+//  ExerciseMechanic.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+enum ExerciseMechanic: String, Codable, Hashable {
+    case compound
+    case isolation
+
+    // MARK: - Properties
+    var displayName: String {
+        rawValue.capitalized
+    }
+}

--- a/WorkoutApp/WorkoutApp/Model/MuscleGroup.swift
+++ b/WorkoutApp/WorkoutApp/Model/MuscleGroup.swift
@@ -1,0 +1,37 @@
+//
+//  MuscleGroup.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+enum MuscleGroup: String, Codable, CaseIterable, Hashable {
+    case abdominals
+    case abductors
+    case adductors
+    case biceps
+    case calves
+    case chest
+    case forearms
+    case glutes
+    case hamstrings
+    case lats
+    case lowerBack = "lower back"
+    case middleBack = "middle back"
+    case neck
+    case quadriceps
+    case shoulders
+    case traps
+    case triceps
+
+    // MARK: - Properties
+    var displayName: String {
+        switch self {
+        case .lowerBack: "Lower Back"
+        case .middleBack: "Middle Back"
+        default: rawValue.capitalized
+        }
+    }
+}

--- a/WorkoutApp/WorkoutApp/Networking/APIClient.swift
+++ b/WorkoutApp/WorkoutApp/Networking/APIClient.swift
@@ -1,0 +1,92 @@
+//
+//  APIClient.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+// MARK: - APIClientProtocol
+protocol APIClientProtocol {
+    func request<T: Decodable>(_ endpoint: Endpoint) async throws -> T
+}
+
+// MARK: - APIClient
+struct APIClient: APIClientProtocol {
+
+    // MARK: - Properties
+    private let baseURL: URL
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let logger = CustomLogger(
+        subsystem: Bundle.main.bundleIdentifier ?? "WorkoutApp",
+        category: "APIClient"
+    )
+
+    // MARK: - Initializers
+    init(baseURL: URL, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        self.decoder = decoder
+    }
+
+    // MARK: - Public Methods
+    func request<T: Decodable>(_ endpoint: Endpoint) async throws -> T {
+        let urlRequest = try buildRequest(for: endpoint)
+        logger.debug("Request: \(endpoint.method.rawValue) \(urlRequest.url?.absoluteString ?? "")")
+
+        let (data, response) = try await session.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.noData
+        }
+
+        logger.debug("Response: \(httpResponse.statusCode) for \(endpoint.path)")
+
+        switch httpResponse.statusCode {
+        case 200...299:
+            do {
+                return try decoder.decode(T.self, from: data)
+            } catch {
+                logger.error("Decoding error for \(endpoint.path): \(error.localizedDescription)")
+                throw NetworkError.decodingError(error)
+            }
+        case 401:
+            throw NetworkError.unauthorized
+        default:
+            throw NetworkError.httpError(statusCode: httpResponse.statusCode)
+        }
+    }
+
+    // MARK: - Private Methods
+    private func buildRequest(for endpoint: Endpoint) throws -> URLRequest {
+        var components = URLComponents(url: baseURL.appending(path: endpoint.path), resolvingAgainstBaseURL: true)
+
+        if !endpoint.queryItems.isEmpty {
+            components?.queryItems = endpoint.queryItems
+        }
+
+        guard let url = components?.url else {
+            throw NetworkError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = endpoint.body
+
+        return request
+    }
+}
+
+// MARK: - MockedAPIClient
+struct MockedAPIClient: APIClientProtocol {
+    func request<T: Decodable>(_ endpoint: Endpoint) async throws -> T {
+        throw NetworkError.noData
+    }
+}

--- a/WorkoutApp/WorkoutApp/Networking/Endpoint.swift
+++ b/WorkoutApp/WorkoutApp/Networking/Endpoint.swift
@@ -1,0 +1,91 @@
+//
+//  Endpoint.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+struct Endpoint {
+
+    // MARK: - Properties
+    let path: String
+    let method: HTTPMethod
+    let queryItems: [URLQueryItem]
+    let body: Data?
+
+    // MARK: - Initializers
+    init(path: String, method: HTTPMethod = .get, queryItems: [URLQueryItem] = [], body: Data? = nil) {
+        self.path = path
+        self.method = method
+        self.queryItems = queryItems
+        self.body = body
+    }
+}
+
+// MARK: - HTTPMethod
+enum HTTPMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+}
+
+// MARK: - Exercise Definition Endpoints
+extension Endpoint {
+    static func exercises(
+        muscle: MuscleGroup? = nil,
+        equipment: Equipment? = nil,
+        category: ExerciseCategory? = nil,
+        page: Int = 0,
+        size: Int = 20
+    ) -> Endpoint {
+        var queryItems = [
+            URLQueryItem(name: "page", value: String(page)),
+            URLQueryItem(name: "size", value: String(size)),
+        ]
+
+        if let muscle {
+            queryItems.append(URLQueryItem(name: "muscle", value: muscle.rawValue))
+        }
+        if let equipment {
+            queryItems.append(URLQueryItem(name: "equipment", value: equipment.rawValue))
+        }
+        if let category {
+            queryItems.append(URLQueryItem(name: "category", value: category.rawValue))
+        }
+
+        return Endpoint(path: "/api/exercises", queryItems: queryItems)
+    }
+
+    static func exercise(id: String) -> Endpoint {
+        Endpoint(path: "/api/exercises/\(id)")
+    }
+
+    static func searchExercises(query: String, page: Int = 0, size: Int = 20) -> Endpoint {
+        Endpoint(
+            path: "/api/exercises/search",
+            queryItems: [
+                URLQueryItem(name: "q", value: query),
+                URLQueryItem(name: "page", value: String(page)),
+                URLQueryItem(name: "size", value: String(size)),
+            ]
+        )
+    }
+
+    static func muscles() -> Endpoint {
+        Endpoint(path: "/api/exercises/muscles")
+    }
+
+    static func equipment() -> Endpoint {
+        Endpoint(path: "/api/exercises/equipment")
+    }
+
+    static func createExercise(_ definition: ExerciseDefinition) -> Endpoint {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let body = try? encoder.encode(definition)
+        return Endpoint(path: "/api/exercises", method: .post, body: body)
+    }
+}

--- a/WorkoutApp/WorkoutApp/Networking/NetworkError.swift
+++ b/WorkoutApp/WorkoutApp/Networking/NetworkError.swift
@@ -1,0 +1,34 @@
+//
+//  NetworkError.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL
+    case httpError(statusCode: Int)
+    case decodingError(Error)
+    case noData
+    case unauthorized
+}
+
+// MARK: - LocalizedError
+extension NetworkError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            "The URL is invalid."
+        case .httpError(let statusCode):
+            "HTTP error with status code \(statusCode)."
+        case .decodingError(let error):
+            "Failed to decode response: \(error.localizedDescription)"
+        case .noData:
+            "No data received from the server."
+        case .unauthorized:
+            "Unauthorized. Please sign in again."
+        }
+    }
+}

--- a/WorkoutApp/WorkoutApp/Networking/PaginatedResponse.swift
+++ b/WorkoutApp/WorkoutApp/Networking/PaginatedResponse.swift
@@ -1,0 +1,16 @@
+//
+//  PaginatedResponse.swift
+//  WorkoutApp
+//
+//  Created by Raul Pele on 22.03.2026.
+//
+
+import Foundation
+
+struct PaginatedResponse<T: Decodable>: Decodable {
+    let content: [T]
+    let totalPages: Int
+    let totalElements: Int
+    let number: Int
+    let last: Bool
+}

--- a/WorkoutApp/WorkoutApp/Utils/Constants.swift
+++ b/WorkoutApp/WorkoutApp/Utils/Constants.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct Constants {
-    
+
     static let appName = "WorkoutApp"
+    static let apiBaseURL = URL(string: "http://172.20.10.7:8080")!
 }

--- a/WorkoutApp/WorkoutApp/Utils/DependencyContainer.swift
+++ b/WorkoutApp/WorkoutApp/Utils/DependencyContainer.swift
@@ -15,16 +15,18 @@ protocol DependencyContainerProtocol {
     var watchCommunicator: any WatchCommunicatorProtocol { get }
     var exerciseRepository: any ExerciseRepositoryProtocol { get }
     var workoutTemplateRepository: any WorkoutRepository { get }
+    var exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol { get }
 }
 
 // MARK: - Live Implementation
 struct DependencyContainer: DependencyContainerProtocol {
-    
+
     let workoutRepository: any WorkoutSessionRepository
     let healthKitManager: any HealthKitManagerProtocol
     let watchCommunicator: any WatchCommunicatorProtocol
     let exerciseRepository: any ExerciseRepositoryProtocol
     let workoutTemplateRepository: any WorkoutRepository
+    let exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol
 
     static func live() -> DependencyContainer {
         let healthKitManager = HealthKitManager()
@@ -35,13 +37,16 @@ struct DependencyContainer: DependencyContainerProtocol {
             workoutRepository: workoutTemplateRepository,
             workoutSessionRepository: workoutRepository
         )
+        let apiClient = APIClient(baseURL: Constants.apiBaseURL)
+        let exerciseDefinitionRepository = ExerciseDefinitionRepository(apiClient: apiClient)
 
         return DependencyContainer(
             workoutRepository: workoutRepository,
             healthKitManager: healthKitManager,
             watchCommunicator: watchCommunicator,
             exerciseRepository: exerciseRepository,
-            workoutTemplateRepository: workoutTemplateRepository
+            workoutTemplateRepository: workoutTemplateRepository,
+            exerciseDefinitionRepository: exerciseDefinitionRepository
         )
     }
 }
@@ -65,6 +70,7 @@ struct MockedDependencyContainer: DependencyContainerProtocol {
     let watchCommunicator: any WatchCommunicatorProtocol
     let exerciseRepository: any ExerciseRepositoryProtocol
     let workoutTemplateRepository: any WorkoutRepository
+    let exerciseDefinitionRepository: any ExerciseDefinitionRepositoryProtocol
 
     init() {
         let workoutTemplateRepository = MockedWorkoutRepository()
@@ -73,5 +79,6 @@ struct MockedDependencyContainer: DependencyContainerProtocol {
         self.exerciseRepository = MockedExerciseRepository()
         self.healthKitManager = MockedHealthKitManager()
         self.watchCommunicator = MockedWatchCommunicator()
+        self.exerciseDefinitionRepository = MockedExerciseDefinitionRepository()
     }
 }


### PR DESCRIPTION
## Summary
- **ExerciseDefinition** domain model with supporting enums (category, equipment, muscle group, force, level, mechanic)
- **ExerciseDefinitionDTO** and **ExerciseDefinitionRepository** for SwiftData persistence
- Networking layer foundation (`APIClient`, `Endpoint`, `NetworkError`, `PaginatedResponse`)
- Exercise browse and detail views integrated into the workout template builder
- Updated DI container registrations and `.gitignore`

## Status
This is an early/WIP version — the exercise data layer and API integration are still in progress.

## Test plan
- [ ] Build the iOS target and verify no compiler errors
- [ ] Navigate to the workout template builder and browse exercises
- [ ] Verify exercise detail view displays correctly
- [ ] Confirm SwiftData persistence of exercise definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)